### PR TITLE
Adding alternate method to find root path

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -39,6 +39,13 @@ public class Application {
             }
             searchDirectory.deleteLastPathComponent()
         }
+        
+        // Get path in alternate way, if first way fails.
+        let currentPath = fileManager.currentDirectoryPath
+        let projectFilePath = currentPath + "/.swiftservergenerator-project"
+        if fileManager.fileExists(atPath: projectFilePath) {
+            return URL(fileURLWithPath: currentPath)
+        }
         return nil
     }
 


### PR DESCRIPTION
When deploying a generated application to Bluemix, I get the "Cannot find project root" error because the implementation of `findProjectRoot` doesn't work because of the way Bluemix handles the project. The addition of this alternate method allows the `findProjectRoot` method to succeed.